### PR TITLE
Use httptest servers for package tests

### DIFF
--- a/webreq_get_test.go
+++ b/webreq_get_test.go
@@ -1,31 +1,46 @@
 package webreq_test
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/tonnytg/webreq"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/tonnytg/webreq"
 )
 
 func TestPackageCall(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/values" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message":"ok"}`))
+	}))
+	defer ts.Close()
 
-	var headersList = make(map[string]string)
-	headersList["Content-Type"] = "application/json"
-
+	headersList := map[string]string{"Content-Type": "application/json"}
 	headers := webreq.NewHeaders(headersList)
 
 	request := webreq.NewRequest("GET")
-	request.SetURL("https://examples.com/values")
-	request.SetHeaders(headers.ListHeaders) // Pass the map directly here
-	request.SetTimeout(10)
+	request.SetURL(ts.URL + "/values")
+	request.SetHeaders(headers.ListHeaders)
+	request.SetTimeout(2)
 
 	body, err := request.Execute()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	bodyString := string(body)
-	if bodyString == "" {
-		t.Error("body is empty")
+	if string(body) == "" {
+		t.Fatal("body is empty")
 	}
 }
 
@@ -35,7 +50,6 @@ func TestSetURL(t *testing.T) {
 		request := webreq.NewRequest("GET")
 		request.SetURL("https://example.com")
 
-		// Verifique se a URL é definida corretamente
 		if request.URL != "https://example.com" {
 			t.Errorf("URL not set correctly")
 		}
@@ -45,17 +59,14 @@ func TestSetURL(t *testing.T) {
 func TestSetTimeout(t *testing.T) {
 	request := webreq.NewRequest("GET")
 	request.SetTimeout(10)
-	if request.TimeoutDuration != (10 * time.Second) {
+	if request.TimeoutDuration != 10*time.Second {
 		fmt.Println(request.TimeoutDuration)
 		t.Error("request.TimeoutDuration is not 10 * time.Second")
 	}
-	return
 }
 
 func TestSetHeaders(t *testing.T) {
-
-	var headersList = make(map[string]string)
-	headersList["Content-Type"] = "application/json"
+	headersList := map[string]string{"Content-Type": "application/json"}
 
 	headers := webreq.NewHeaders(headersList)
 	if headers.ListHeaders["Content-Type"] != "application/json" {
@@ -67,11 +78,9 @@ func TestSetHeaders(t *testing.T) {
 	if request.ErrorMessage != "" {
 		t.Error("request.ErrorMessage is not empty")
 	}
-	return
 }
 
 func TestSetHeaders2(t *testing.T) {
-
 	headers := webreq.NewHeaders(nil)
 	headers.Add("Content-Type", "application/json")
 	if headers.ListHeaders["Content-Type"] != "application/json" {
@@ -83,21 +92,17 @@ func TestSetHeaders2(t *testing.T) {
 	if request.ErrorMessage != "" {
 		t.Error("request.ErrorMessage is not empty")
 	}
-	return
 }
 
 func TestSetData(t *testing.T) {
-
 	request := webreq.NewRequest("GET")
 	request.SetData([]byte("test"))
 	if request.ErrorMessage != "" {
 		t.Error("request.ErrorMessage is not empty")
 	}
-	return
 }
 
 func TestSetMethod(t *testing.T) {
-
 	request := webreq.NewRequest("GET")
 	if request == nil {
 		t.Error("request is nil")
@@ -116,11 +121,9 @@ func TestSetMethod(t *testing.T) {
 	if request.ErrorMessage != "request method is empty" {
 		t.Error("request.Method is not empty")
 	}
-	return
 }
 
 func TestSetStatusCode(t *testing.T) {
-
 	request := webreq.NewRequest("GET")
 	if request == nil {
 		t.Error("request is nil")
@@ -129,11 +132,9 @@ func TestSetStatusCode(t *testing.T) {
 	if request.StatusCode != 200 {
 		t.Error("request.StatusCode is not 200")
 	}
-	return
 }
 
 func TestSetNewRequest(t *testing.T) {
-
 	newRequest := webreq.NewRequest("GET")
 	if newRequest == nil {
 		t.Error("newRequest is nil")
@@ -141,6 +142,18 @@ func TestSetNewRequest(t *testing.T) {
 }
 
 func TestEndToEnd(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Fatalf("unexpected content type: %s", r.Header.Get("Content-Type"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		response := map[string]string{"status": "ok"}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer ts.Close()
 
 	headers := webreq.NewHeaders(nil)
 	headers.Add("Content-Type", "application/json")
@@ -149,7 +162,7 @@ func TestEndToEnd(t *testing.T) {
 	if request == nil {
 		t.Error("request is nil")
 	}
-	request.SetURL("https://example.com/values")
+	request.SetURL(ts.URL)
 	if request.ErrorMessage != "" {
 		t.Error("request.ErrorMessage is not empty")
 	}
@@ -157,14 +170,13 @@ func TestEndToEnd(t *testing.T) {
 	if request.ErrorMessage != "" {
 		t.Error("request.ErrorMessage is not empty")
 	}
-	request.SetTimeout(10)
+	request.SetTimeout(2)
 
 	body, err := request.Execute()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	bodyString := string(body)
-	if bodyString == "" {
-		t.Error("body is empty")
+	if len(body) == 0 {
+		t.Fatal("body is empty")
 	}
 }

--- a/webreq_post_test.go
+++ b/webreq_post_test.go
@@ -2,9 +2,12 @@ package webreq_test
 
 import (
 	"encoding/json"
-	"github.com/tonnytg/webreq"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/tonnytg/webreq"
 )
 
 type Friend struct {
@@ -15,6 +18,29 @@ type Friend struct {
 }
 
 func TestPackagePost(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method: %s", r.Method)
+		}
+		if r.URL.Path != "/values" {
+			t.Fatalf("unexpected path: %s", r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Fatalf("unexpected content type: %s", ct)
+		}
+		defer r.Body.Close()
+		var payload Friend
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		if payload.Name == "" {
+			t.Fatal("expected name in payload")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"received": payload.Name})
+	}))
+	defer ts.Close()
 
 	headers := webreq.NewHeaders(nil)
 	headers.Add("Content-Type", "application/json")
@@ -29,24 +55,22 @@ func TestPackagePost(t *testing.T) {
 		FamilyName: "Gomes",
 	}
 
-	// convert f to bytes
 	fBytes, err := json.Marshal(f)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	request := webreq.NewRequest("POST")
-	request.SetURL("https://examples.com/values")
+	request.SetURL(ts.URL + "/values")
 	request.SetData(fBytes)
-	request.SetHeaders(headers.ListHeaders) // Set map directly
-	request.SetTimeout(10)
+	request.SetHeaders(headers.ListHeaders)
+	request.SetTimeout(2)
 
 	body, err := request.Execute()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	bodyString := string(body)
-	if bodyString == "" {
-		t.Error("body is empty")
+	if len(body) == 0 {
+		t.Fatal("body is empty")
 	}
 }


### PR DESCRIPTION
## Summary
- replace GET and POST integration tests to use local httptest servers instead of external endpoints
- strengthen assertions around request method, path, headers, and payload handling in the tests
- shorten timeouts in tests to keep the suite fast while avoiding network hangs

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68eea0879c008320bf52fbfdab930d7f